### PR TITLE
fix: Troca "session-file-store" por "connect-loki"

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "bcryptjs": "^2.4.3",
     "connect-flash": "^0.1.1",
+    "connect-loki": "^1.1.0",
     "express": "^4.16.4",
     "express-session": "^1.16.1",
     "moment": "^2.24.0",
@@ -26,7 +27,6 @@
     "nunjucks": "^3.2.0",
     "nunjucks-date-filter": "^0.1.1",
     "pg": "^7.9.0",
-    "sequelize": "^5.6.0",
-    "session-file-store": "^1.2.0"
+    "sequelize": "^5.6.0"
   }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,6 @@
 const express = require('express')
 const session = require('express-session')
-const FileStore = require('session-file-store')(session)
+const LokiStore = require('connect-loki')(session)
 const nunjucks = require('nunjucks')
 const path = require('path')
 const flash = require('connect-flash')
@@ -21,12 +21,11 @@ class App {
     this.express.use(flash())
     this.express.use(
       session({
-        name: 'root',
+        store: new LokiStore({
+          path: path.resolve(__dirname, '..', 'tmp', 'sessions.db')
+        }),
         secret: 'MyAppSecret',
         resave: true,
-        store: new FileStore({
-          path: path.resolve(__dirname, '..', 'tmp', 'sessions')
-        }),
         saveUninitialized: true
       })
     )


### PR DESCRIPTION
Oi pessoal. Inicialmente, estavam utilizando a biblioteca "session-file-store". Porém, como a biblioteca estava apresentando problemas em algumas situações, essa parte específica foi regravada com a biblioteca "connect-loki". Estou enviando esse PR para atualizar o código-fonte, pois facilita a consulta posterior, não precisando rever o vídeo. Espero que ajude :pray:.